### PR TITLE
Add command-line options to launch emulator with specified ROM and datapack file paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ Win32/*
 *.VC.opendb
 *.VC.db
 *.vcxproj.user
+*.o
+.qmake.stash
+moc_*
+qrc_resources.cpp
+ui_createpakdialog.h
+ui_mainwindow.h

--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -192,7 +192,7 @@
   </action>
   <action name="actionInsertPakC">
    <property name="text">
-    <string>Insert</string>
+    <string>Insert...</string>
    </property>
   </action>
   <action name="actionEjectPakC">

--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -40,7 +40,7 @@
   <property name="unifiedTitleAndToolBarOnMac">
    <bool>false</bool>
   </property>
-  <widget class="QWidget" name="centralWidget">
+  <widget class="QOpenGLWidget" name="centralWidget">
    <widget class="QWidget" name="widget" native="true">
     <property name="geometry">
      <rect>
@@ -78,11 +78,16 @@
      <enum>Qt::NoContextMenu</enum>
     </property>
    </widget>
+  </widget>
+  <widget class="QStatusBar">
+   <property name="sizeGripEnabled">
+    <bool>false</bool>
+   </property>
    <widget class="QProgressBar" name="speed">
     <property name="geometry">
      <rect>
       <x>380</x>
-      <y>170</y>
+      <y>0</y>
       <width>118</width>
       <height>23</height>
      </rect>

--- a/inc/mainwindow.h
+++ b/inc/mainwindow.h
@@ -17,6 +17,7 @@ public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
     void* getDrawingArea();
+	void setSkipCloseConfirmation(bool skip);
 
 private slots:
 	void closeEvent(QCloseEvent *event);
@@ -41,6 +42,8 @@ private:
 
     Ui::MainWindow *ui;
 	QTimer *everySecondTimer;
+
+	bool skipCloseConfirmation = false;
 };
 
 #endif // MAINWINDOW_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 ﻿#include "mainwindow.h"
 #include <QApplication>
+#include <QCommandLineParser>
 #include "emucore.h"
 #include "global.h"
 #include <stdio.h>
@@ -7,11 +8,52 @@
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
+    QCommandLineParser parser;
+
+    parser.setApplicationDescription("Cross Platform - Psion Organiser II Emulator");
+    parser.addHelpOption();
+
+    QCommandLineOption romFileOption(
+        {"r", "rom-file"},
+        "Path to ROM file to boot",
+        "file"
+    );
+
+    QCommandLineOption pakBFileOption(
+        {"b", "pak-b-file"},
+        "Path to OPK file to use for the slot B datapack",
+        "file"
+    );
+
+    QCommandLineOption pakCFileOption(
+        {"c", "pak-c-file"},
+        "Path to OPK file to use for the slot C datapack",
+        "file"
+    );
+
+    parser.addOption(romFileOption);
+    parser.addOption(pakBFileOption);
+    parser.addOption(pakCFileOption);
+
+    parser.process(app);
+
     MainWindow mainWin;
     mainWin.show();
 
     emucore = new EmuCore(mainWin.getDrawingArea());
     emucore->startCore();
+
+    QString romFile = parser.value(romFileOption);
+    QString pakBFile = parser.value(pakBFileOption);
+    QString pakCFile = parser.value(pakCFileOption);
+
+    if (!romFile.isEmpty() || !pakBFile.isEmpty() || !pakCFile.isEmpty()) {
+        if (!romFile.isEmpty()) emucore->load(romFile.toStdString());
+        if (!pakBFile.isEmpty()) emucore->insertPak(1, pakBFile.toStdString());
+        if (!pakCFile.isEmpty()) emucore->insertPak(0, pakCFile.toStdString());
+
+        emucore->setPower(true);
+    }
 
     app.exec();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,25 +15,31 @@ int main(int argc, char *argv[])
 
     QCommandLineOption romFileOption(
         {"r", "rom-file"},
-        "Path to ROM file to boot",
+        "Path to ROM file to boot.",
         "file"
     );
 
     QCommandLineOption pakBFileOption(
         {"b", "pak-b-file"},
-        "Path to OPK file to use for the slot B datapack",
+        "Path to OPK file to use for the slot B datapack.",
         "file"
     );
 
     QCommandLineOption pakCFileOption(
         {"c", "pak-c-file"},
-        "Path to OPK file to use for the slot C datapack",
+        "Path to OPK file to use for the slot C datapack.",
         "file"
+    );
+
+    QCommandLineOption skipCloseConfirmation(
+        "no-close-confirm",
+        "Skip confirmation dialog when closing application."
     );
 
     parser.addOption(romFileOption);
     parser.addOption(pakBFileOption);
     parser.addOption(pakCFileOption);
+    parser.addOption(skipCloseConfirmation);
 
     parser.process(app);
 
@@ -53,6 +59,10 @@ int main(int argc, char *argv[])
         if (!pakCFile.isEmpty()) emucore->insertPak(0, pakCFile.toStdString());
 
         emucore->setPower(true);
+    }
+
+    if (parser.isSet(skipCloseConfirmation)) {
+        mainWin.setSkipCloseConfirmation(true);
     }
 
     app.exec();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -40,6 +40,7 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 	QString message = "An error occured while trying to save RAM. Changes to RAM cannot be saved at this time.";
 	if (suc == FILEIO_SaveFail_PowerOn) {
 		message = "The emulator is not switched off. Changes to RAM cannot be saved at this time.";
+		if (skipCloseConfirmation) return;
 	}
 	bool ret = popupDialogCustom(message, "Are you sure you want to quit anyway?", QMessageBox::Warning, "Quit Anyway");
 	if (!ret) {
@@ -76,6 +77,11 @@ void MainWindow::popupDialog(QString mainText, QString infoText, QMessageBox::Ic
 void* MainWindow::getDrawingArea()
 {
     return (void*) ui->widget->winId();
+}
+
+void MainWindow::setSkipCloseConfirmation(bool skip)
+{
+	skipCloseConfirmation = skip;
 }
 
 void MainWindow::on_actionLoad_ROM_triggered()


### PR DESCRIPTION
Hi there,

Just thought I'd contribute a few command-line options that can be used to start the emulator with a ROM pre-loaded, without needing to open the right ROM file from the file picker. I've also implemented command-line options to pre-load datapacks, too. More info on the options is available by running `psiora` with the `--help` flag.

I needed to implement this in order to use your emulator as part of my efforts to write my own datapacks in 6303 assembly — being able to quickly launch the emulator with the latest assembled datapack already enabled makes debugging my own code much easier. Thought I'd share my changes upstream so that others can benefit from this feature.

I also fixed an issue where SDL2 was not able to write characters to the screen as part of LCD emulation, I believe due to conflicts with Qt 5 which is using OpenGL (SDL2 was unable to grab the rendering context when needed). I'm not sure if this bug is just a Linux thing (what I'm using). I've implemented a minor fix in the .ui file to use a `QOpenGLWidget`, which fixed the issue. I then also proceeded to nest the progress bar in a `QStatusBar` in order to ensure that the UI looks okay. You may need to try out these changes on your end to ensure that they work as intended for you.

Many thanks,
-James.